### PR TITLE
feat(): add no-script for improved lighthouse score

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -24,6 +24,8 @@
 <body>
 
   <my-app></my-app>
-
+  <noscript>
+    This App Requires Javascript!
+  </noscript>
 </body>
 </html>


### PR DESCRIPTION
Whey you run a lighthouse review of the app, there is only one failure which is to show some content if javascript is disabled. I added a no-script portion to the body in order to pass this test.
<img width="712" alt="screen shot 2018-01-17 at 10 30 32 pm" src="https://user-images.githubusercontent.com/7246257/35084050-e7153f30-fbd6-11e7-9439-c6328a573e81.png">

