### PR TITLE
Add `--prerender` option to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dist/"
   ],
   "scripts": {
-    "build": "stencil build",
+    "build": "stencil build --prerender",
     "dev": "sd concurrent \"stencil build --dev --watch\" \"stencil-dev-server\" ",
     "devWithSW": "sd concurrent \"stencil build --dev --service-worker --watch\" \"stencil-dev-server\" ",
     "serve": "stencil-dev-server",


### PR DESCRIPTION
According to the README.md and other blogs, from this repository you should get a PWA that has 100s across the board in lighthouse scores. However I don't see this. 

```
git clone https://github.com/ionic-team/ionic-pwa-toolkit.git my-pwa
cd my-pwa
npm install
npm build
npx http-server ./www
```

For me this produces:
![screen shot 2018-02-07 at 08 51 18](https://user-images.githubusercontent.com/3168135/35906890-1cd2ef7e-0be4-11e8-95a2-0775caa05d26.png)

I believe this is because the pre-render step is not being run in the build. The `stencil` CLI has `--prerender` as an optional flag, but it is not enabled by default.

If I run the same build but with adding `--prerender` to the build script, I get:

![screen shot 2018-02-07 at 08 55 41](https://user-images.githubusercontent.com/3168135/35907072-bd1626cc-0be4-11e8-8996-049e48301b08.png)

(the other non-100s are just my own other problems :) )