### PR TITLE
test(app-profile): select the correct element’s text content

### DIFF
--- a/src/components/app-profile/app-profile.spec.ts
+++ b/src/components/app-profile/app-profile.spec.ts
@@ -28,7 +28,10 @@ describe('app-profile', () => {
       }
       
       await flush(element);
-      expect(element.textContent).toEqual('Hello! My name is stencil. My name was passed in through a route param!');
+
+      const pElement = element.querySelector('ion-content p');
+
+      expect(pElement.textContent).toEqual('Hello! My name is stencil. My name was passed in through a route param!');
     });
   });
 });


### PR DESCRIPTION
Fixes the app-profile test by selecting the correct element for the test

Fixes: #18 