### PR TITLE
feat(dev): Update workbox 3.2.0 version reference

### DIFF
--- a/src/sw.js
+++ b/src/sw.js
@@ -1,4 +1,4 @@
-importScripts('workbox-v3.0.0-alpha.6/workbox-sw.js')
+importScripts('workbox-v3.2.0/workbox-sw.js')
 
 self.workbox.skipWaiting();
 self.workbox.clientsClaim();


### PR DESCRIPTION
Generated was failing due to npm installing workbox version 3.2.0 whereas version 3.0.0-alpha.6 was referenced