### PR TITLE
feat(manifest): adds missing entries in manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,12 +2,21 @@
   "name": "Ionic PWA Toolkit",
   "short_name": "Ionic PWA",
   "start_url": "/",
+  "dir": "ltr",
+  "lang": "en",
+  "scope": "/",
   "display": "standalone",
-  "icons": [{
-    "src": "assets/icon/icon.png",
-    "sizes": "512x512",
-    "type": "image/png"
-  }],
+  "description": "Ionic PWA Toolkit",
+  "orientation": "any",
+  "related_applications": [],
+  "prefer_related_applications": false,
+  "icons": [
+    {
+      "src": "assets/icon/icon.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ],
   "background_color": "#488aff",
   "theme_color": "#488aff"
 }


### PR DESCRIPTION
## Contents
Adding a few entries to show what is possible:
- [dir](https://www.w3.org/TR/appmanifest/#dir-member)
- [lang](https://www.w3.org/TR/appmanifest/#lang-member)
- [scope](https://www.w3.org/TR/appmanifest/#scope-member)
- [description](https://www.w3.org/TR/appmanifest/#description-member)
- [orientation](https://www.w3.org/TR/appmanifest/#orientation-member)
- [related_applications](https://www.w3.org/TR/appmanifest/#related_applications-member)
- [prefer_related_applications](https://www.w3.org/TR/appmanifest/#prefer_related_applications-member)

## Reference:
- https://www.w3.org/TR/appmanifest/#example-manifests

## Discussion
I don't know if the convention is to hide entries with default values or to show them for anyone to see what is possible.
Both options have pros/cons. 

You be the judge 👍