### PR TITLE
build: prettier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/jest": "^26.0.24",
     "jest": "^26.6.3",
     "jest-cli": "^26.6.3",
+    "prettier": "^2.4.1",
     "puppeteer": "^10.0.0"
   }
 }


### PR DESCRIPTION
### Build

There is a `.prettierrc` configuration file in the repo but, there isn't any dependency on prettier. This PR add such dependency to the project.